### PR TITLE
Upgrade to shopify_api v7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in shopify_graphql_client.gemspec
 gemspec
 
+gem "shopify_api", ">= 7.0.1"
+
 gem "pry"
 gem "dotenv"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    shopify_graphql_client (0.2.0)
+    shopify_graphql_client (0.2.1)
       graphql-client (~> 0.14.0)
-      shopify_api (>= 5.2, < 7.0)
+      shopify_api (>= 5.2)
 
 GEM
   remote: https://rubygems.org/
@@ -62,8 +62,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    shopify_api (6.0.0)
-      activeresource (>= 3.0.0)
+    shopify_api (7.0.1)
+      activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack
     thread_safe (0.3.6)
@@ -81,6 +81,7 @@ DEPENDENCIES
   pry-rescue (~> 1.5)
   rake (~> 10.0)
   rspec (~> 3.8)
+  shopify_api (>= 7.0.1)
   shopify_graphql_client!
 
 BUNDLED WITH

--- a/bin/console
+++ b/bin/console
@@ -8,7 +8,11 @@ shop_domain = ENV["SHOP_DOMAIN"]
 auth_token = ENV["OAUTH_TOKEN"]
 
 if shop_domain && auth_token
-  session = ShopifyAPI::Session.new(shop_domain, auth_token)
+  session = ShopifyAPI::Session.new(
+    domain: shop_domain,
+    token: auth_token,
+    api_version: "2019-04",
+  )
   ShopifyAPI::Base.activate_session(session)
 end
 

--- a/lib/shopify_graphql_client/version.rb
+++ b/lib/shopify_graphql_client/version.rb
@@ -1,3 +1,3 @@
 module ShopifyGraphQLClient
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/shopify_graphql_client.gemspec
+++ b/shopify_graphql_client.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
 
   spec.add_runtime_dependency "graphql-client", "~> 0.14.0"
-  spec.add_runtime_dependency "shopify_api", [">= 5.2", "< 7.0"]
+  spec.add_runtime_dependency "shopify_api", [">= 5.2"]
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -12,8 +12,9 @@ describe "client" do
     GRAPHQL
 
     session = ShopifyAPI::Session.new(
-      ENV.fetch("SHOP_DOMAIN") + ".myshopify.com",
-      ENV.fetch("OAUTH_TOKEN"),
+      domain: ENV.fetch("SHOP_DOMAIN") + ".myshopify.com",
+      token: ENV.fetch("OAUTH_TOKEN"),
+      api_version: "2019-04",
     )
 
     ShopifyAPI::Base.activate_session(session)


### PR DESCRIPTION
fixes #1

- remove the upper version bound on the shopify_api dependency
- use add `shopify_api ">= 7.0.1"` to Gemfile to use it when running console and rspec
- update console and rspec to create the session using the new syntax